### PR TITLE
add ユーザー登録画面の項目数を定義書に合わせて変更

### DIFF
--- a/app/MUser.php
+++ b/app/MUser.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App;
+
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class MUser extends Authenticatable
+{
+    use Notifiable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'password',
+        'last_name',
+        'first_name',
+        'postcode',
+        'prefecture',
+        'municipality',
+        'address',
+        'apartments',
+        'email',
+        'phone_number',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password', 'remember_token',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
+}


### PR DESCRIPTION
ユーザー登録画面を画面定義書の項目数に合わせて編集しました。
DB連携・登録とログインのテストも完了しています。

よろしくお願いいたします。